### PR TITLE
fix fall damage

### DIFF
--- a/scripts/Game/Components/Damage/GRAD_CharacterDamageManagerComponent.c
+++ b/scripts/Game/Components/Damage/GRAD_CharacterDamageManagerComponent.c
@@ -14,6 +14,7 @@ modded class SCR_CharacterDamageManagerComponent : ScriptedDamageManagerComponen
 		if (!hzOwner)
 			return;
 		
+		if (instigator) {
 		if (EntityUtils.IsPlayer(hzOwner))
 		{
 			if(GetDefaultHitZone().GetHealthScaled() < 0.01)
@@ -24,6 +25,7 @@ modded class SCR_CharacterDamageManagerComponent : ScriptedDamageManagerComponen
 				
 				//Print("Set Health to 1%");
 			}
+		}
 		}
 
 		


### PR DESCRIPTION
untested proposed changes to fix missing fall damage

checks for instigator and only reduces damage when one is found (assuming fall damage has no instigator)

however this might lead to respawn/death after falling exzessive heights as a drawback